### PR TITLE
Add directory selection modal

### DIFF
--- a/wp-content/plugins/github-deployer/assets/css/admin.css
+++ b/wp-content/plugins/github-deployer/assets/css/admin.css
@@ -1,0 +1,30 @@
+.gd-modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0,0,0,0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10000;
+}
+
+.gd-modal {
+    background: #fff;
+    padding: 20px;
+    max-width: 500px;
+    max-height: 400px;
+    overflow: auto;
+}
+
+.gd-folder-list a {
+    display: block;
+    padding: 4px 0;
+}
+
+.gd-breadcrumb {
+    margin-bottom: 10px;
+}
+

--- a/wp-content/plugins/github-deployer/assets/js/admin.js
+++ b/wp-content/plugins/github-deployer/assets/js/admin.js
@@ -1,0 +1,77 @@
+(function($){
+    var ajaxUrl = (typeof gd_vars !== 'undefined' && gd_vars.ajaxurl) ? gd_vars.ajaxurl : (typeof ajaxurl !== 'undefined' ? ajaxurl : '');
+
+    function openFolderModal($input){
+        var $overlay = $('<div class="gd-modal-overlay"><div class="gd-modal"><p>Loading...</p></div></div>');
+        $('body').append($overlay);
+        var $modal = $overlay.find('.gd-modal');
+
+        function load(path){
+            $.get(ajaxUrl, { action: 'gd_browse_dir', path: path }, function(resp){
+                if(!resp.success){
+                    $modal.html('<p>Error loading directory.</p>');
+                    return;
+                }
+                render(resp.data.path, resp.data.folders);
+            });
+        }
+
+        function render(path, dirs){
+            var crumbs = buildBreadcrumb(path);
+            var html = '<div class="gd-breadcrumb">'+crumbs+'</div>';
+            html += '<div class="gd-folder-list">';
+            if(dirs.length){
+                dirs.forEach(function(d){
+                    html += '<a href="#" data-path="'+d.path+'">'+d.name+'</a>';
+                });
+            } else {
+                html += '<em>No subdirectories</em>';
+            }
+            html += '</div>';
+            html += '<p><button class="button gd-choose-folder">Choose this folder</button> <button class="button gd-cancel">Cancel</button></p>';
+            $modal.html(html);
+
+            $modal.find('.gd-folder-list a').on('click', function(e){
+                e.preventDefault();
+                load($(this).data('path'));
+            });
+            $modal.find('.gd-breadcrumb a').on('click', function(e){
+                e.preventDefault();
+                load($(this).data('path'));
+            });
+            $modal.find('.gd-choose-folder').on('click', function(){
+                $input.val(path);
+                $overlay.remove();
+            });
+            $modal.find('.gd-cancel').on('click', function(){
+                $overlay.remove();
+            });
+        }
+
+        function buildBreadcrumb(path){
+            var parts = path.split('/').filter(function(p){ return p.length; });
+            var crumbPath = '';
+            var html = '<a href="#" data-path="/">/</a>';
+            parts.forEach(function(p){
+                crumbPath += '/' + p;
+                html += ' / <a href="#" data-path="'+crumbPath+'">'+p+'</a>';
+            });
+            return html;
+        }
+
+        $overlay.on('click', function(e){
+            if($(e.target).hasClass('gd-modal-overlay')){
+                $overlay.remove();
+            }
+        });
+
+        load('/');
+    }
+
+    $(document).on('click', '.gd-find-folder', function(e){
+        e.preventDefault();
+        var $input = $(this).closest('form').find('input[name="folder"]');
+        openFolderModal($input);
+    });
+})(jQuery);
+

--- a/wp-content/plugins/github-deployer/includes/class-filesystem.php
+++ b/wp-content/plugins/github-deployer/includes/class-filesystem.php
@@ -63,13 +63,39 @@ return empty( $files );
  *
  * @return bool
  */
-public function unzip( $zip_file, $destination, $overwrite = false ) {
-$unzip_result = unzip_file( $zip_file, $destination, $overwrite );
+    public function unzip( $zip_file, $destination, $overwrite = false ) {
+        $unzip_result = unzip_file( $zip_file, $destination, $overwrite );
 
 if ( is_wp_error( $unzip_result ) ) {
 return false;
 }
 
-return true;
-}
+        return true;
+    }
+
+    /**
+     * List sub directories of a path.
+     *
+     * @param string $path Path to list.
+     *
+     * @return array
+     */
+    public function list_folders( $path ) {
+        $dirs   = $this->fs->dirlist( $path );
+        $result = array();
+
+        if ( is_array( $dirs ) ) {
+            foreach ( $dirs as $name => $info ) {
+                if ( 'd' === $info['type'] ) {
+                    $full = ( '/' === $path ) ? '/' . $name : trailingslashit( $path ) . $name;
+                    $result[] = array(
+                        'name' => $name,
+                        'path' => $full,
+                    );
+                }
+            }
+        }
+
+        return $result;
+    }
 }

--- a/wp-content/plugins/github-deployer/includes/class-ui.php
+++ b/wp-content/plugins/github-deployer/includes/class-ui.php
@@ -25,17 +25,21 @@ public function __construct( $plugin ) {
 $this->plugin = $plugin;
 add_action( 'admin_menu', array( $this, 'admin_menu' ) );
 add_action( 'admin_post_gd_save_token', array( $this, 'save_token' ) );
-add_action( 'admin_post_gd_save_mapping', array( $this, 'save_mapping' ) );
-add_action( 'admin_post_gd_deploy_repo', array( $this, 'deploy_repo' ) );
-add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
-}
+        add_action( 'admin_post_gd_save_mapping', array( $this, 'save_mapping' ) );
+        add_action( 'admin_post_gd_deploy_repo', array( $this, 'deploy_repo' ) );
+        add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+        add_action( 'wp_ajax_gd_browse_dir', array( $this, 'ajax_browse_dir' ) );
+    }
 
 /**
  * Enqueue admin assets.
  */
 public function enqueue_assets() {
 wp_enqueue_style( 'gd-admin', plugins_url( '../assets/css/admin.css', __FILE__ ), array(), GitHub_Deployer::VERSION );
-wp_enqueue_script( 'gd-admin', plugins_url( '../assets/js/admin.js', __FILE__ ), array( 'jquery' ), GitHub_Deployer::VERSION, true );
+    wp_enqueue_script( 'gd-admin', plugins_url( '../assets/js/admin.js', __FILE__ ), array( 'jquery' ), GitHub_Deployer::VERSION, true );
+    wp_localize_script( 'gd-admin', 'gd_vars', array(
+        'ajaxurl' => admin_url( 'admin-ajax.php' ),
+    ) );
 }
 
 /**
@@ -116,8 +120,8 @@ exit;
 /**
  * Deploy repository.
  */
-public function deploy_repo() {
-$repo   = sanitize_text_field( $_GET['repo'] );
+    public function deploy_repo() {
+        $repo   = sanitize_text_field( $_GET['repo'] );
 $mappings = get_option( 'gd_repo_mappings', array() );
 
 if ( empty( $mappings[ $repo ] ) ) {
@@ -148,7 +152,28 @@ $message = 'Download failed.';
 
 $this->plugin->logger->log( $repo, 'default', $folder, $success, $message );
 
-wp_redirect( admin_url( 'tools.php?page=github-deployer' ) );
-exit;
-}
+        wp_redirect( admin_url( 'tools.php?page=github-deployer' ) );
+        exit;
+    }
+
+    /**
+     * AJAX handler to browse directories.
+     */
+    public function ajax_browse_dir() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( 'Unauthorized', 403 );
+        }
+
+        $path = isset( $_GET['path'] ) ? sanitize_text_field( wp_unslash( $_GET['path'] ) ) : '/';
+        if ( '' === $path ) {
+            $path = '/';
+        }
+
+        $folders = $this->plugin->filesystem->list_folders( $path );
+
+        wp_send_json_success( array(
+            'path'    => $path,
+            'folders' => $folders,
+        ) );
+    }
 }

--- a/wp-content/plugins/github-deployer/views/settings-page.php
+++ b/wp-content/plugins/github-deployer/views/settings-page.php
@@ -33,6 +33,7 @@
 <input type="hidden" name="action" value="gd_save_mapping" />
 <input type="hidden" name="repo" value="<?php echo esc_attr( $full ); ?>" />
 <input type="text" name="folder" value="<?php echo esc_attr( isset( $mappings[ $full ] ) ? $mappings[ $full ] : '' ); ?>" class="regular-text" />
+<button type="button" class="button gd-find-folder" style="margin-left:4px;">Find Folder...</button>
 <input type="submit" class="button" value="Save Mapping" />
 </form>
 </td>
@@ -74,4 +75,5 @@ Set folder first
 <?php endif; ?>
 </tbody>
 </table>
+<div id="gd-folder-modal" style="display:none;"></div>
 </div>


### PR DESCRIPTION
## Summary
- add ability to browse directories when mapping repos
- implement AJAX handler and filesystem helper
- include modal UI scripts and styles
- localize AJAX URL for directory browser

## Testing
- ❌ `php -l wp-content/plugins/github-deployer/includes/class-ui.php` (fail: command not found)
- ❌ `php -l wp-content/plugins/github-deployer/includes/class-filesystem.php` (fail: command not found)

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.